### PR TITLE
[Chore] Add solr-jsonl-chunk-loader as a symlink to solr-bulk repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/solr-jsonl-loader"]
+	path = bin/solr-jsonl-loader
+	url = https://github.com/ebi-gene-expression-group/solr-jsonl-loader.git

--- a/bin/solr-jsonl-chunk-loader.sh
+++ b/bin/solr-jsonl-chunk-loader.sh
@@ -1,0 +1,1 @@
+solr-jsonl-loader/solr-jsonl-chunk-loader.sh


### PR DESCRIPTION
Changes:

- Added solr-jsonl-loader as a submodule
- Replaced solr-jsonl-chunk-loader.sh with a symlink that point to the similarly named file in the previously added submodule. That file in the submodule is going to be shared across other repositories, too.